### PR TITLE
Refactor channel queue to deque, template class, perfect forwarding

### DIFF
--- a/include/PTPLib/net/Channel.hpp
+++ b/include/PTPLib/net/Channel.hpp
@@ -19,12 +19,12 @@
 #include <map>
 #include <algorithm>
 #include <chrono>
-#include <queue>
+#include <deque>
 #include <cassert>
 
 namespace PTPLib::net {
 
-    using queue_event = std::queue<PTPLib::net::SMTS_Event>;
+    using queue_event = std::deque<PTPLib::net::SMTS_Event>;
     using map_solver_clause = std::map<std::string, std::vector<PTPLib::net::Lemma>>;
     using time_duration = std::chrono::duration<double>;
 
@@ -52,15 +52,14 @@ namespace PTPLib::net {
 
     public:
         Channel()
-                :
-                requestStop(false),
-                reset(false),
-                isStopping(false),
-                clauseShareMode(false),
-                shouldLearnClause(true),
-                clauseLearnDuration(1000),
-                cube_and_conquer(false),
-                color_mode(false)
+        : requestStop(false)
+        , reset(false)
+        , isStopping(false)
+        , clauseShareMode(false)
+        , shouldLearnClause(true)
+        , clauseLearnDuration(1000)
+        , cube_and_conquer(false)
+        , color_mode(false)
         {
             m_learned_clauses = std::make_unique<map_solver_clause>();
             m_pulled_clauses = std::make_unique<map_solver_clause>();
@@ -111,15 +110,22 @@ namespace PTPLib::net {
 
         SMTS_Event pop_front_query() {
             SMTS_Event tmp_p(std::move(queries.front()));
-            queries.pop();
+            queries.pop_front();
             return tmp_p;
         }
 
         std::string & front_query() { return queries.front().header.at(PTPLib::common::Param.COMMAND); }
 
-        void push_back_query(SMTS_Event && hd) {
-            assert((not hd.header.at(PTPLib::common::Param.NODE).empty()) and (not hd.header.at(PTPLib::common::Param.NAME).empty()));
-            queries.push(std::move(hd));
+        template<class T>
+        void push_back_event(T && event) {
+            assert((not event.header.at(PTPLib::common::Param.NODE).empty()) and (not event.header.at(PTPLib::common::Param.NAME).empty()));
+            queries.push_back(std::forward<T>(event));
+        }
+
+        template<class T>
+        void push_front_event(T && event) {
+            assert((not event.header.at(PTPLib::common::Param.NODE).empty()) and (not event.header.at(PTPLib::common::Param.NAME).empty()));
+            queries.push_front(std::forward<T>(event));
         }
 
         void set_current_header(PTPLib::net::Header & hd) {

--- a/tests/protocol_example/CMakeLists.txt
+++ b/tests/protocol_example/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 
 set(PTPLib_branch ${branch})
 if(NOT PTPLib_branch )
-    set(PTPLib_branch master)
+    set(PTPLib_branch dequeOfEvents)
 endif()
 
 project(Protocol-Example)

--- a/tests/protocol_example/Communicator.cc
+++ b/tests/protocol_example/Communicator.cc
@@ -34,8 +34,8 @@ void Communicator::communicate_worker()
                 // Report Solver Result
             }
 
-        } else if (not getChannel().isEmpty_query()) {
-            auto event = getChannel().pop_front_query();
+        } else if (not getChannel().isEmpty_event()) {
+            auto event = getChannel().pop_front_event();
             assert(not event.header[PTPLib::common::Param.COMMAND].empty());
             stream.println(color_enabled ? PTPLib::common::Color::FG_Cyan : PTPLib::common::Color::FG_DEFAULT,
                             "[t COMMUNICATOR ] -> ", "updating the channel with ",
@@ -101,7 +101,7 @@ bool Communicator::execute_event(const PTPLib::net::SMTS_Event & event, bool & s
     } else if (event.header.at(PTPLib::common::Param.COMMAND) == PTPLib::common::Command.INCREMENTAL)
         shouldUpdateSolverAddress = true;
 
-    if (not channel.isEmpty_query() and channel.front_query() == PTPLib::common::Command.STOP)
+    if (not channel.isEmpty_event() and channel.front_event() == PTPLib::common::Command.STOP)
         return false;
 
     return true;

--- a/tests/protocol_example/Communicator.h
+++ b/tests/protocol_example/Communicator.h
@@ -10,7 +10,7 @@
 #include "SMTSolver.cc"
 
 class Communicator {
-    PTPLib::net::Channel & channel;
+    PTPLib::net::Channel<PTPLib::net::SMTS_Event, PTPLib::net::Lemma> & channel;
     SMTSolver solver;
     PTPLib::common::synced_stream & stream;
     PTPLib::common::StoppableWatch timer;
@@ -21,7 +21,7 @@ class Communicator {
 
 public:
 
-    Communicator(PTPLib::net::Channel & ch, PTPLib::common::synced_stream & ss, const bool & ce, double seed, PTPLib::threads::ThreadPool & th)
+    Communicator(PTPLib::net::Channel<PTPLib::net::SMTS_Event, PTPLib::net::Lemma> & ch, PTPLib::common::synced_stream & ss, const bool & ce, double seed, PTPLib::threads::ThreadPool & th)
         :
         channel(ch),
         solver(ch, ss, timer, ce, seed),
@@ -36,6 +36,6 @@ public:
 
     void communicate_worker();
 
-    PTPLib::net::Channel & getChannel() { return channel;};
+    PTPLib::net::Channel<PTPLib::net::SMTS_Event, PTPLib::net::Lemma> & getChannel() { return channel;};
 
 };

--- a/tests/protocol_example/Listener.cc
+++ b/tests/protocol_example/Listener.cc
@@ -310,15 +310,14 @@ void Listener::periodic_clauseLearning_worker()
 {
     int random_n = waiting_duration ? waiting_duration * (100) : SMTSolver::generate_rand(1000, 2000);
     if (getChannel().isClauseShareMode()) {
-        getChannel().setClauseLearnDuration(random_n*2);
         th_pool.push_task
         (
-            [this]
+            [this, random_n]
             {
                 while (true)
                 {
                     std::unique_lock<std::mutex> lk(channel.getMutex());
-                    if (getChannel().wait_for_reset(lk, std::chrono::milliseconds(getChannel().getClauseLearnDuration())))
+                    if (getChannel().wait_for_reset(lk, std::chrono::milliseconds(static_cast<int>(random_n*2))))
                         break;
                     assert([&]() {
                         if (not lk.owns_lock()) {
@@ -330,7 +329,7 @@ void Listener::periodic_clauseLearning_worker()
                     lk.unlock();
                 }
                 stream.println(color_enabled ? PTPLib::common::Color::FG_BrightBlue : PTPLib::common::Color::FG_DEFAULT,
-                           "[t CLAUSELEARN ] -> clause learn timout: ", getChannel().getClauseLearnDuration());
+                           "[t CLAUSELEARN ] -> clause learn timout: ", random_n);
             },
             ::get_task_name(PTPLib::common::TASK::CLAUSELEARN)
        );

--- a/tests/protocol_example/Listener.h
+++ b/tests/protocol_example/Listener.h
@@ -7,7 +7,7 @@
 #include <PTPLib/threads/ThreadPool.hpp>
 
 class Listener {
-    PTPLib::net::Channel channel;
+    PTPLib::net::Channel<PTPLib::net::SMTS_Event, PTPLib::net::Lemma> channel;
     PTPLib::threads::ThreadPool th_pool;
     Communicator communicator;
     PTPLib::common::synced_stream & stream;
@@ -52,11 +52,11 @@ public:
 
     bool read_lemma(std::vector<PTPLib::net::Lemma> & lemmas, PTPLib::net::Header & header);
 
-    bool write_lemma(std::unique_ptr<PTPLib::net::map_solver_clause> const & lemmas, PTPLib::net::Header & header);
+    bool write_lemma(std::unique_ptr<PTPLib::net::map_solverBranch_lemmas> const & lemmas, PTPLib::net::Header & header);
 
     void memory_checker();
 
-    PTPLib::net::Channel & getChannel() { return channel;};
+    PTPLib::net::Channel<PTPLib::net::SMTS_Event, PTPLib::net::Lemma> & getChannel() { return channel;};
 
     PTPLib::threads::ThreadPool & getPool() { return th_pool; }
 

--- a/tests/protocol_example/Listener.h
+++ b/tests/protocol_example/Listener.h
@@ -43,7 +43,8 @@ public:
 
     PTPLib::net::SMTS_Event generate_event(int counter, int solve_time);
 
-    void queue_event(PTPLib::net::SMTS_Event && header_payload);
+    template<class T>
+    bool queue_event(T && event);
 
     void pull_clause_worker(double seed, double n_min, double n_max);
 

--- a/tests/protocol_example/SMTSolver.cc
+++ b/tests/protocol_example/SMTSolver.cc
@@ -72,7 +72,7 @@ SMTSolver::Result SMTSolver::search(char * smt_lib) {
     return solver_result;
 }
 
-void SMTSolver::inject_clauses(PTPLib::net::map_solver_clause & pulled_clauses)
+void SMTSolver::inject_clauses(PTPLib::net::map_solverBranch_lemmas & pulled_clauses)
 {
     stream.println(color_enabled ? PTPLib::common::Color::FG_Cyan : PTPLib::common::Color::FG_DEFAULT,
                    "[t COMMUNICATOR ] -> inject pulled clause ");

--- a/tests/protocol_example/SMTSolver.h
+++ b/tests/protocol_example/SMTSolver.h
@@ -8,7 +8,7 @@ public:
     enum class Result { SAT, UNSAT, UNKNOWN };
 
 private:
-    PTPLib::net::Channel & channel;
+    PTPLib::net::Channel<PTPLib::net::SMTS_Event, PTPLib::net::Lemma> & channel;
     bool learnSomeClauses(std::vector<PTPLib::net::Lemma> & learned_clauses);
     Result do_solve();
     Result result;
@@ -19,7 +19,7 @@ private:
     std::atomic<std::thread::id> thread_id;
 
 public:
-    SMTSolver(PTPLib::net::Channel & ch, PTPLib::common::synced_stream & st, PTPLib::common::StoppableWatch & tm, const bool & ce, double wd)
+    SMTSolver(PTPLib::net::Channel<PTPLib::net::SMTS_Event, PTPLib::net::Lemma> & ch, PTPLib::common::synced_stream & st, PTPLib::common::StoppableWatch & tm, const bool & ce, double wd)
     :
             channel (ch),
             result (Result::UNKNOWN),
@@ -33,13 +33,13 @@ public:
 
     Result   getResult()  const    { return result; }
 
-    PTPLib::net::Channel& getChannel() const    { return channel; }
+    PTPLib::net::Channel<PTPLib::net::SMTS_Event, PTPLib::net::Lemma> & getChannel() const    { return channel; }
 
     static int generate_rand(int min, int max);
 
     SMTSolver::Result search(char * smt_lib);
 
-    void inject_clauses(PTPLib::net::map_solver_clause & pulled_clauses);
+    void inject_clauses(PTPLib::net::map_solverBranch_lemmas & pulled_clauses);
 
     void initialise_logic();
 

--- a/tests/protocol_example/main.cc
+++ b/tests/protocol_example/main.cc
@@ -68,12 +68,7 @@ int main(int argc, char** argv) {
                     }
                     return true;
                 }());
-                if (event.header[PTPLib::common::Param.COMMAND] == PTPLib::common::Command.STOP) {
-                    reset = true;
-                    if (not listener.getChannel().isEmpty_query())
-                        listener.getChannel().clear_queries();
-                }
-                listener.queue_event(std::move(event));
+                reset = listener.queue_event(std::move(event));
             }
             if (reset)
                 break;


### PR DESCRIPTION
- Refactor channel queue to deque to prioritize stop/reset events so that all non-stop/reset events will be push_back and only stop/reset will be push_front 

- Refactor to use perfect forwarding

- Choose better variable names

- Refactor channel to template class
