### PR TITLE
Update max_size to 100

### DIFF
--- a/include/PTPLib/common/PartitionConstant.hpp
+++ b/include/PTPLib/common/PartitionConstant.hpp
@@ -59,7 +59,7 @@ namespace PTPLib::common
     } Param;
 
     static struct {
-        CONST_SIZE MAX_SIZE = 10000;
+        CONST_SIZE MAX_SIZE = 100;
     } STATS;
 
     enum TASK


### PR DESCRIPTION
Following Plots will confirm that max_size of 100 doesn't have overhead and unsound result while learning clauses and partitioning.

![cactus-plot-resultdir-100To1000](https://user-images.githubusercontent.com/17990258/187668561-5fda9cf9-e12e-4ad4-ab29-0fe4825a66e9.png)
![cactus-plot-resultdir-clause](https://user-images.githubusercontent.com/17990258/187668605-7f040405-6d72-4196-bf81-56e5eb64738d.png)
