### PR TITLE
CI: upgrade pip to fix ModuleNotFoundError: No module named 'skbuild'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ jobs:
                     yum -y install rh-python38
                     yum -y install python3-pip
                     yum -y install zlib-devel
+                    pip3 install --upgrade pip
                     pip3 install wheel
                     echo "pip3 install pyinstaller" |scl enable devtoolset-8 bash
             - run:


### PR DESCRIPTION
Upgrade pip on CI job